### PR TITLE
Field Definitions to align with NACHA Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midlandsbank/node-nacha",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "NACHA ACH EFT File Parser/Formatter for CCD+ / PPD+ / CTX+",
   "keywords": [

--- a/src/fieldDefinitions/addenda.ts
+++ b/src/fieldDefinitions/addenda.ts
@@ -20,7 +20,6 @@ export const addenda: FieldDefs<Addenda> = {
   },
   entryDetailSequenceNum: {
     position: [88, 94],
-    numeric: true,
     validator: {
       regex: /\d{7}/,
       message: "entryDetailSequenceNum must be 7 digits",

--- a/src/fieldDefinitions/batch.ts
+++ b/src/fieldDefinitions/batch.ts
@@ -43,6 +43,7 @@ export const batchHeader: FieldDefs<BatchHeader> = {
     optional: true,
   },
   originatorStatusCode: {
+    numeric: true,
     position: [79, 79],
   },
   originatingDFIIdentification: {


### PR DESCRIPTION
Updated Addenda.entryDetailSequence number to be string instead of a number to align with trace # & Batch.originatorStatusCode to by a number. 